### PR TITLE
Added `encoding='utf8'` parameter

### DIFF
--- a/liwc/dic.py
+++ b/liwc/dic.py
@@ -33,7 +33,7 @@ def read_dic(filepath):
     * `lexicon` is a dict mapping string patterns to lists of category names
     * `category_names` is a list of category names (as strings)
     """
-    with open(filepath) as lines:
+    with open(filepath, encoding='utf8') as lines:
         # read up to first "%" (should be very first line of file)
         for line in lines:
             if line.strip() == "%":


### PR DESCRIPTION
Added `encoding='utf8'` parameter to the open function located in read_dic function for special characters.

I've had a problem when I tried to classify texts with a translated LIWC Dictionary.

So when I try to parse this sentence "kabul terketmek naber yawru a asit kürtaj yapabilmek." it does not classify the word "kürtaj" because it contains "ü".

I solved this issue by adding the encoding parameter to the open function where it reads .dic file.