### PR TITLE
Filter empty categories, to support jMFD

### DIFF
--- a/liwc/dic.py
+++ b/liwc/dic.py
@@ -23,7 +23,7 @@ def _parse_lexicon(lines, category_mapping):
     for line in lines:
         line = line.strip()
         parts = line.split("\t")
-        yield parts[0], [category_mapping[category_id] for category_id in parts[1:]]
+        yield parts[0], [category_mapping[category_id] for category_id in parts[1:] if category_id]
 
 
 def read_dic(filepath):


### PR DESCRIPTION
This dictionary: https://github.com/soramame0518/j-mfd uses two tabs to separate word from category. I suppose it works with the liwc program and so I have made the addition of filtering empty categories so that it can be used with this code too.